### PR TITLE
MNT: Replace pkg_resources usage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ RUN apt-get update \
     && apt-get install -y \
     build-essential \
     python3-pip \
-    python3.11 \
+    python3.10 \
     git \
     && python3 -m pip install --upgrade pip \
     && python3 -m pip install --upgrade setuptools \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,13 @@
 # Container image that runs your code.
 # NOTE: Could speed things up if you use an existing image with all the
 #       deps pre-installed but still not as fast as TypeScript.
-FROM ubuntu:20.04
+FROM ubuntu:22.04
 
 RUN apt-get update \
     && apt-get install -y \
     build-essential \
     python3-pip \
-    python3.8 \
+    python3.11 \
     git \
     && python3 -m pip install --upgrade pip \
     && python3 -m pip install --upgrade setuptools \

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -l
 
-PYTHON=$(which python3.11)
+PYTHON=$(which python3.10)
 echo "PYTHON=${PYTHON}"
 
 $PYTHON /check_changelog.py

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,6 +1,6 @@
 #!/bin/bash -l
 
-PYTHON=$(which python3.8)
+PYTHON=$(which python3.11)
 echo "PYTHON=${PYTHON}"
 
 $PYTHON /check_changelog.py


### PR DESCRIPTION
Replace `pkg_resources` usage because it is deprecated. Also bump Ubuntu and Python versions.

Fix #7
