### PR TITLE
BUG+ENH: Fix towncrier dep and add some functionality

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,8 +12,7 @@ RUN apt-get update \
     && python3 -m pip install --upgrade pip \
     && python3 -m pip install --upgrade setuptools \
     && python3 -m pip install --upgrade wheel \
-    && python3 -m pip install PyGithub \
-    && python3 -m pip install toml
+    && python3 -m pip install PyGithub toml towncrier
 
 # Copies code file action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -18,21 +18,24 @@ jobs:
     name: Check if towncrier change log entry is correct
     runs-on: ubuntu-latest
     steps:
-    - uses: scientific-python/action-towncrier-changelog@0.1.1
+    - uses: scientific-python/action-towncrier-changelog@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BOT_USERNAME: changelog-bot
 ```
 
 Your repository must contain a `pyproject.toml` in the root directory
-with the appropriate configurations. A partial example as follows:
+with the appropriate configurations. An example showing all options is:
 
 ```
 [tool.changelog-bot]
     [tool.changelog-bot.towncrier_changelog]
-        enabled = true
-        verify_pr_number = true
-        changelog_skip_label = "no-changelog-entry-needed"
+        enabled = true  # default is false
+        verify_pr_number = true  # default is false
+        changelog_skip_label = "no-changelog-entry-needed"  # default is none
+        changelog_noop_label = "skip-changelog-checks"
+        whatsnew_label = "whatsnew-needed"
+        whatsnew_pattern = '''docs\/whatsnew\/\d+\.\d+\.rst'''
 
 [tool.towncrier]
     package = "yourpackagename"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
     name: Check if towncrier change log entry is correct
     runs-on: ubuntu-latest
     steps:
-    - uses: scientific-python/action-towncrier-changelog@0.1
+    - uses: scientific-python/action-towncrier-changelog@0.1.1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         BOT_USERNAME: changelog-bot

--- a/check_changelog.py
+++ b/check_changelog.py
@@ -261,7 +261,7 @@ if cl_config.get('verify_pr_number', False):
         print(
             f"No number in the changelog file(s) match this pull request number "
             f'({pr_num}):\n{file_names}')
-    sys.exit(1)
+        sys.exit(1)
 
 # Success!
 print(f'Changelog file correctly added for PR {pr_num}:\n{file_names}')

--- a/check_changelog.py
+++ b/check_changelog.py
@@ -245,13 +245,16 @@ def check_changelog_type(types, matching_file):
     return len(components) > 1 and components[1] in types
 
 
-for matching_file in matching_files:
-    if not check_changelog_type(types, matching_file):
-        print(
-            f'The changelog file "{matching_file}" that was added for PR {pr_num} is '
-            f'not one of the configured types: {types}'
-        )
-        sys.exit(1)
+bad_files = "\n".join(
+    matching_file for matching_file in matching_files
+    if not check_changelog_type(types, matching_file)
+)
+if bad_files:
+    print(
+        f'The changelog file(s):\n"{bad_files}"in PR {pr_num} must '
+        f'be one of the configured types: {types}'
+    )
+    sys.exit(1)
 
 
 # TODO: Make this a regex to check that the number is in the right place etc.

--- a/check_changelog.py
+++ b/check_changelog.py
@@ -262,8 +262,8 @@ file_names = "\n".join(matching_files)
 if cl_config.get('verify_pr_number', False):
     if not all(str(pr_num) in matching_file for matching_file in matching_files):
         print(
-            f"Not all number in the changelog file number(s) match this pull request "
-            f"number ({pr_num}):\n{file_names}"
+            f"Not all changelog file number(s) match this pull request number "
+            f"({pr_num}):\n{file_names}"
         )
         sys.exit(1)
 

--- a/check_changelog.py
+++ b/check_changelog.py
@@ -188,6 +188,7 @@ def check_sections(filenames, sections):
     """Check that a file matches ``<section><issue number>``.
     Otherwise the root dir matches when it shouldn't.
     """
+    files = list()
     for section in sections:
         # Make sure the path ends with a /
         if not section.endswith("/"):
@@ -196,8 +197,8 @@ def check_sections(filenames, sections):
         for fname in filenames:
             match = re.match(pattern, fname)
             if match is not None:
-                return fname
-    return False
+                files.append(fname)
+    return files
 
 
 config = parse_toml(toml_cfg)

--- a/check_changelog.py
+++ b/check_changelog.py
@@ -251,7 +251,7 @@ bad_files = "\n".join(
 )
 if bad_files:
     print(
-        f'The changelog file(s):\n"{bad_files}"in PR {pr_num} must '
+        f'The changelog file(s):\n\n{bad_files}\nin PR {pr_num} must '
         f'be one of the configured types: {types}'
     )
     sys.exit(1)

--- a/check_changelog.py
+++ b/check_changelog.py
@@ -257,7 +257,7 @@ for matching_file in matching_files:
 # TODO: Make this a regex to check that the number is in the right place etc.
 file_names = "\n".join(matching_files)
 if cl_config.get('verify_pr_number', False):
-    if not any(str(pr_num) in matching_file for matching_file in matching_files):
+    if not all(str(pr_num) in matching_file for matching_file in matching_files):
         print(
             f"No number in the changelog file(s) match this pull request number "
             f'({pr_num}):\n{file_names}')

--- a/check_changelog.py
+++ b/check_changelog.py
@@ -241,13 +241,13 @@ if not matching_files:
 def check_changelog_type(types, matching_file):
     filename = Path(matching_file).name
     components = filename.split(".")
-    return components[1] in types
+    return len(components) > 1 and components[1] in types
 
 
 for matching_file in matching_files:
     if not check_changelog_type(types, matching_file):
         print(
-            f'The changelog file {matching_file} that was added for PR {pr_num} is '
+            f'The changelog file "{matching_file}" that was added for PR {pr_num} is '
             f'not one of the configured types: {types}'
         )
         sys.exit(1)

--- a/check_changelog.py
+++ b/check_changelog.py
@@ -262,8 +262,9 @@ file_names = "\n".join(matching_files)
 if cl_config.get('verify_pr_number', False):
     if not all(str(pr_num) in matching_file for matching_file in matching_files):
         print(
-            f"No number in the changelog file(s) match this pull request number "
-            f'({pr_num}):\n{file_names}')
+            f"Not all number in the changelog file number(s) match this pull request "
+            f"number ({pr_num}):\n{file_names}"
+        )
         sys.exit(1)
 
 # Success!


### PR DESCRIPTION
1. `towncrier` wasn't installed but is necessary. Does this mean nobody is using 0.1.1 of the action? :eyes: 
2. Tolerate multiple changelog entries being modified: as long as at least one matches the PR number you should be okay. Sometimes in PRs I edit other existing entries to fix them etc. -- seems like as long as there is at least one changed file the check should pass.
3. Better check for PR number, avoid IndexError when filename does not have a dot in it